### PR TITLE
[PoC] Install Rust toolchain

### DIFF
--- a/build-rwasm/Dockerfile
+++ b/build-rwasm/Dockerfile
@@ -1,6 +1,38 @@
 # Container image that runs your code
 FROM ghcr.io/r-wasm/webr:main
 
+# Copied from https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-debian.template
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=nightly
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e7b0f47557c1afcd86939b118cbcf7fb95a5d1d917bdd355157b63ca00fc4333' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y \
+        --no-modify-path \
+        --profile minimal \
+        --default-toolchain $RUST_VERSION \
+        --default-host ${rustArch} \
+        --target wasm32-unknown-emscripten \
+        --component rust-src; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY code.R /code.R
 


### PR DESCRIPTION
The step of Rust installation might be better done in `r-wasm/webr` image, but anyway I needed this to compile my Rust-powered R package on GitHub Actions. Since this step is executed on the dedicated image for this, I found there's no way to stop `cargo: command not found` error other than tweaking the Dockerfile like this. Hope this helps who are interested in webr and Rust.

An example workflow file: https://github.com/yutannihilation/savvy-webr-test/blob/master/.github/workflows/deploy-cran-repo.yml