### PR TITLE
Provide an empty set to workflow_dispatch to quiet the YAML formatter warnings.

### DIFF
--- a/.github/workflows/_testing-repo.yml
+++ b/.github/workflows/_testing-repo.yml
@@ -3,7 +3,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 name: r-wasm/actions - repo
 

--- a/examples/deploy-cran-repo.yml
+++ b/examples/deploy-cran-repo.yml
@@ -5,7 +5,7 @@ on:
     # Only build on main or master branch
     branches: [main, master]
   # Or when triggered manually
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 name: Build and deploy wasm R package repository
 


### PR DESCRIPTION
Minor change that just adds an empty set `{}` next to the `workflow_dispatch:` key. 