### PR TITLE
Separate the "build a package with `rwasm`" and "deploy package to a GH pages repo" tests

### DIFF
--- a/.github/workflows/_testing-build.yml
+++ b/.github/workflows/_testing-build.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch: {}
+
+name: r-wasm/actions - build-rwasm
+
+jobs:
+  build-rwasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./build-rwasm
+        with:
+          packages: cli
+          image-path: _image
+          repo-path: _repo
+      - name: Verify repo exists
+        shell: Rscript {0}
+        run: |
+          print(dir("_repo", recursive = TRUE))
+          stopifnot(dir.exists("_repo/src"))
+          stopifnot(dir.exists("_repo/bin"))
+      - name: Verify image exists
+        shell: Rscript {0}
+        run: |
+          print(dir("_image", recursive = TRUE))
+          stopifnot(file.exists("_image/library.data"))
+          stopifnot(file.exists("_image/library.js.metadata"))

--- a/.github/workflows/_testing-repo.yml
+++ b/.github/workflows/_testing-repo.yml
@@ -1,8 +1,6 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
   workflow_dispatch: {}
 
 name: r-wasm/actions - repo
@@ -16,25 +14,3 @@ jobs:
       repository-projects: read
       pages: write
       id-token: write
-
-  build-rwasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./build-rwasm
-        with:
-          packages: cli
-          image-path: _image
-          repo-path: _repo
-      - name: Verify repo exists
-        shell: Rscript {0}
-        run: |
-          print(dir("_repo", recursive = TRUE))
-          stopifnot(dir.exists("_repo/src"))
-          stopifnot(dir.exists("_repo/bin"))
-      - name: Verify image exists
-        shell: Rscript {0}
-        run: |
-          print(dir("_image", recursive = TRUE))
-          stopifnot(file.exists("_image/library.data"))
-          stopifnot(file.exists("_image/library.js.metadata"))


### PR DESCRIPTION
Deploying to GitHub Pages fails when running actions for a submitted PR.

This change separates the `build-rwasm` test and `deploy-cran-repo` tests into separate workflows and tweaks the `_testing-repo.yml` workflow so that it is not triggered on a PR, but still runs on merging.