### PR TITLE
Add workflow input for setting the webR Docker image container

### DIFF
--- a/.github/workflows/_testing-build.yml
+++ b/.github/workflows/_testing-build.yml
@@ -29,3 +29,18 @@ jobs:
           print(dir("_image", recursive = TRUE))
           stopifnot(file.exists("_image/library.data"))
           stopifnot(file.exists("_image/library.js.metadata"))
+  build-rwasm-fixed-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./build-rwasm
+        with:
+          packages: cran/cli@3.6.2
+          image-path: _image
+          repo-path: _repo
+          webr-image: ghcr.io/r-wasm/webr:v0.3.3
+      - name: Verify repo built for webR v0.3.3 exists
+        shell: Rscript {0}
+        run: |
+          print(dir("_repo", recursive = TRUE))
+          stopifnot(dir.exists("_repo/bin/emscripten/contrib/4.3/"))

--- a/.github/workflows/_testing-build.yml
+++ b/.github/workflows/_testing-build.yml
@@ -11,7 +11,7 @@ jobs:
   build-rwasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./build-rwasm
         with:
           packages: cli
@@ -32,7 +32,7 @@ jobs:
   build-rwasm-fixed-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./build-rwasm
         with:
           packages: cran/cli@3.6.2

--- a/.github/workflows/deploy-cran-repo.yml
+++ b/.github/workflows/deploy-cran-repo.yml
@@ -13,6 +13,11 @@ on:
         default: ""
         type: string
         required: false
+      webr-image:
+        description: Docker container image for webR development environment. Defaults to the latest version of webR.
+        default: "ghcr.io/r-wasm/webr:main"
+        type: string
+        required: false
 
 name: Build and deploy wasm R package repository
 
@@ -67,6 +72,7 @@ jobs:
           # If `.pkgs` does not exist, use `inputs.packages`
           packages: ${{ steps.packages-file.outputs.pkgs || inputs.packages }}
           repo-path: _site
+          webr-image: ${{ inputs.webr-image }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/release-file-system-image.yml
+++ b/.github/workflows/release-file-system-image.yml
@@ -19,6 +19,11 @@ on:
         default: "NULL"
         type: string
         required: false
+      webr-image:
+        description: Docker container image for webR development environment. Defaults to the latest version of webR.
+        default: "ghcr.io/r-wasm/webr:main"
+        type: string
+        required: false
 
 name: Build & Upload wasm R package image
 
@@ -74,6 +79,7 @@ jobs:
             ${{ steps.needs.outputs.pkg }}
           strip: ${{ inputs.strip }}
           image-path: ._rwasm
+          webr-image: ${{ inputs.webr-image }}
 
       - name: Upload wasm image to release
         uses: svenstaro/upload-release-action@v2

--- a/build-rwasm/Dockerfile
+++ b/build-rwasm/Dockerfile
@@ -1,5 +1,7 @@
+ARG WEBR_IMAGE=ghcr.io/r-wasm/webr:main
+
 # Container image that runs your code
-FROM ghcr.io/r-wasm/webr:main
+FROM $WEBR_IMAGE
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY code.R /code.R

--- a/build-rwasm/Dockerfile
+++ b/build-rwasm/Dockerfile
@@ -6,6 +6,10 @@ FROM $WEBR_IMAGE
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY code.R /code.R
 
+# TODO: Remove this workaround for r-wasm/webr#422 when no longer needed
+RUN find /root/R/x86_64-pc-linux-gnu-library -maxdepth 2 -wholename '*/pak' -exec rm -rf {} \;
+RUN /opt/R/current/bin/R -q -e 'install.packages("pak", lib = .Library)'
+
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT [ "Rscript" ]
 # ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/build-rwasm/action.yml
+++ b/build-rwasm/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   strip:
     description: |
-      A set of [directories to remove](https://r-wasm.github.io/rwasm/reference/make_library.html#details) when building the WebAssembly R package library image, or `NULL` to remove nothign (the default). To achieve a smaller bundle size, it is recommended to set `strip` to `"demo, doc, examples, help, html, include, tests, vignette"`.
+      A set of [directories to remove](https://r-wasm.github.io/rwasm/reference/make_library.html#details) when building the WebAssembly R package library image, or `NULL` to remove nothing (the default). To achieve a smaller bundle size, it is recommended to set `strip` to `"demo, doc, examples, help, html, include, tests, vignette"`.
     default: "NULL"
     required: false
   image-path:
@@ -18,11 +18,18 @@ inputs:
     description: Directory where the R package repository should be saved.
     default: "_site"
     required: false
+  webr-image:
+    description: Docker container image for webR development environment.
+    default: "ghcr.io/r-wasm/webr:main"
+    type: string
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     # - Rscript
+    - --build-arg
+    - WEBR_IMAGE=${{ inputs.webr-image }}
     - /code.R
     - ${{ inputs.image-path }}
     - ${{ inputs.repo-path }}

--- a/build-rwasm/action.yml
+++ b/build-rwasm/action.yml
@@ -24,14 +24,20 @@ inputs:
     type: string
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    # - Rscript
-    - --build-arg
-    - WEBR_IMAGE=${{ inputs.webr-image }}
-    - /code.R
-    - ${{ inputs.image-path }}
-    - ${{ inputs.repo-path }}
-    - ${{ inputs.packages }}
-    - ${{ inputs.strip }}
+#  using: 'docker'
+#  image: 'Dockerfile'
+#  args:
+#    - /code.R
+#    - ${{ inputs.image-path }}
+#    - ${{ inputs.repo-path }}
+#    - ${{ inputs.packages }}
+#    - ${{ inputs.strip }}
+# TODO: Remove this below workaround for https://github.com/orgs/community/discussions/25241
+  using: 'composite'
+  steps:
+    - run: docker build build-rwasm --build-arg WEBR_IMAGE=${{ inputs.webr-image }} -t r-wasm-build-rwasm:${GITHUB_SHA}
+      shell: bash
+    - run: |
+        docker run --rm -v $(pwd):/github/workspace --workdir /github/workspace r-wasm-build-rwasm:${GITHUB_SHA} \
+        /code.R "${{ inputs.image-path }}" "${{ inputs.repo-path }}" "${{ inputs.packages }}" "${{ inputs.strip }}"
+      shell: bash

--- a/build-rwasm/code.R
+++ b/build-rwasm/code.R
@@ -31,7 +31,6 @@ if (is.character(strip) && length(strip) == 1 && strip == "NULL") strip <- NULL
 cat("\nArgs:\n")
 str(list(image_path = image_path, repo_path = repo_path, packages = packages, strip = strip))
 
-if (!require("pak", character.only = TRUE, quietly = TRUE)) install.packages("pak")
 if (!require("withr", character.only = TRUE, quietly = TRUE)) install.packages("withr")
 
 # Work in the GHA directory so that package reference 'local::.' works as expected


### PR DESCRIPTION
See the discussion at https://github.com/posit-dev/shinylive/issues/131 for more details.

---

~~Note: CI is failing for this PR, due to an error from `pak`. I'm unsure what's caused this, and investigating...~~

After discussion with Gabor, I now know what's happening. See https://github.com/r-wasm/webr/pull/422 for details. We'll need to continue to work around the problem for now, since the fix to webR's Docker images won't apply retroactively.